### PR TITLE
Update ntlmrequest.js

### DIFF
--- a/lib/ntlmrequest.js
+++ b/lib/ntlmrequest.js
@@ -74,7 +74,7 @@ function ntlmRequest(opts) {
 				}
 
 				if (supportedAuthSchemes.indexOf('ntlm') !== -1) {
-					authHeader = ntlm.createType1Message();
+					authHeader = ntlm.createType1Message(opts.workstation, opts.target);
 				} else if (supportedAuthSchemes.indexOf('basic') !== -1) {
 					authHeader = 'Basic ' + new Buffer(opts.username + ':' + opts.password).toString('base64');
 					ntlmState.status = 2;


### PR DESCRIPTION
This helps if you are nocking the requests to the EWS server.  If you nock the requests it generates a hash using your local machine name.  Then using those auth headers, running them on a build server, the auth headers are different.  This lets you specify the hostname of the machine so the hashes are always the same and match your nocked requests.