### PR TITLE
Honour ADFS redirects.

### DIFF
--- a/lib/ntlmrequest.js
+++ b/lib/ntlmrequest.js
@@ -28,11 +28,19 @@ function ntlmRequest(opts) {
 			}
 		});
 
-	function createRequestOptions(authHeader) {
+	function createRequestOptions(authHeader, res) {
 		let obj = {
 			uri: opts.uri,
 			method: opts.method
 		};
+
+		if (res) {
+			// If while handling the previous ntlmState.status we were redirected, submit
+			// subsequent requests to the redirect location (including parameters, e.g. ?SAMLRequest),
+			// otherwise subsequent steps in the authentication process will follow.
+			obj.uri = res.request.href;
+			obj.method = res.request.method;
+		}
 
 		if (opts.request) {
 			extend(true, obj, opts.request, {
@@ -122,7 +130,7 @@ function ntlmRequest(opts) {
 
 		ntlmState.status++;
 
-		ntlmRequestObj(createRequestOptions(authHeader), sendRequest.bind(this, resolve, reject));
+		ntlmRequestObj(createRequestOptions(authHeader, res), sendRequest.bind(this, resolve, reject));
 	}
 
 	return new Promise(sendRequest);


### PR DESCRIPTION
Fixes authentication for the ADFS server I am authenticating against because it redirects both to different relative path and appends a ?SAMLRequest=... query parameter in the redirect Location. Without these subsequent stages of the authentication process fail. Setting  request.followRedirect: true isn't enough because that correctly causes redirects to be followed within a single stage of the authentication, but then subsequent stages revert to the original URL provided by the caller, not the redirected URL.